### PR TITLE
Set defaultPublishableKey on STPAPIClient before paying in order to w…

### DIFF
--- a/src/ios/CordovaStripe.swift
+++ b/src/ios/CordovaStripe.swift
@@ -384,6 +384,7 @@ public class CordovaStripe: CDVPlugin {
         }
 
         let pm = STPPaymentHandler.shared()
+        STPAPIClient.shared.publishableKey = StripeAPI.defaultPublishableKey
         pm.confirmPayment(pip, with: self) { (status, pi, err) in
             switch status {
             case .failed:


### PR DESCRIPTION
Set defaultPublishableKey on STPAPIClient before paying in order to work correctly with more than one Stripe account in a single app (Fix Code=50 “No such payment_intent” when confirm payment intent)